### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can directly add the `MHRadialProgressView.h` and `MHRadialProgressView.m` s
 3. Include MHRadialProgressView with `#import "MHRadialProgressView.h"`.
 
 
-### Cocoapods
+### CocoaPods
 [CocoaPods](http://cocoapods.org) is the recommended way to add MHRadialProgressView to your project.
 
 1. Add a pod entry for MHRadialProgressView to your Podfile `pod 'MHRadialProgressView', '~> 0.2'`


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
